### PR TITLE
fix/actions checkout

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- chore: developmentブランチに自動でマージするgithub actionsの設定
- fix: リポジトリの読み書き権限を与える
- chore: github action checkoutのバージョンをあげる
